### PR TITLE
assoc transit-params, even if it isn't a map

### DIFF
--- a/src/ring/middleware/transit.clj
+++ b/src/ring/middleware/transit.clj
@@ -56,11 +56,10 @@
       (handler request))))
 
 (defn- assoc-transit-params [request transit]
-  (if (map? transit)
-    (-> request
-        (assoc :transit-params transit)
-        (update-in [:params] merge transit))
-    request))
+  (let [request (assoc request :transit-params transit)]
+    (if (map? transit)
+      (update-in request [:params] merge transit)
+      request)))
 
 (defn wrap-transit-params
   "Middleware that parses the body of Transit requests into a map of parameters,


### PR DESCRIPTION
Since transit can encode any of Clojure's data structures, there should be no reason not to `assoc` it into the request if it isn't a map.
