### PR TITLE
Change request Content-Type header check to be case-insensitive

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,6 @@
         :url "https://github.com/jalehman/ring-transit"}
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.cognitect/transit-clj "0.8.283"]
+                 [com.cognitect/transit-clj "0.8.285"]
                  [prismatic/plumbing "0.5.0"]
                  [ring/ring-core "1.4.0"]])

--- a/src/ring/middleware/transit.clj
+++ b/src/ring/middleware/transit.clj
@@ -20,7 +20,7 @@
     (not (empty? (re-find #"^application/transit\+(json|msgpack)" type)))))
 
 (defn- transit-request? [request]
-  (when-let [type (get-in request [:headers "Content-Type"])]
+  (when-let [type (get-header request "Content-Type")]
     (let [mtch (re-find #"^application/transit\+(json|msgpack)" type)]
       [(not (empty? mtch)) (keyword (second mtch))])))
 

--- a/test/ring/middleware/test/transit.clj
+++ b/test/ring/middleware/test/transit.clj
@@ -23,7 +23,13 @@
         (is (= (handler request)
                {:status  400
                 :headers {"Content-Type" "text/plain"}
-                :body    "Malformed Transit in request body."})))))
+                :body    "Malformed Transit in request body."}))))
+
+    (testing "headers are accessed in a case-insensitive manner"
+      (let [request  {:headers {"content-type" "application/transit+json; charset=UTF-8"}
+                      :body (string-input-stream "[\"^ \",\"monni\",\"tiskaa\"]")}
+            response (handler request)]
+        (is (= {"monni" "tiskaa"} (:body response))))))
 
   (let [handler (wrap-transit-body identity {:keywords? true})]
     (testing "keyword keys"


### PR DESCRIPTION
As Ring SPEC specifies, the header map actually contains downcased keys, so checking just for "Content-Type" never returns anything with Ring. So better just use the get-header utility function to get the header in a case-insensitive manner.