### PR TITLE
Bump dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,6 @@
         :url "https://github.com/jalehman/ring-transit"}
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.cognitect/transit-clj "0.8.285"]
-                 [prismatic/plumbing "0.5.0"]
+                 [com.cognitect/transit-clj "0.8.313"]
+                 [prismatic/plumbing "0.5.5"]
                  [ring/ring-core "1.4.0"]])


### PR DESCRIPTION
Also removes this warning

```
WARNING: Inst already refers to: #'clojure.core/Inst in namespace: schema.core, being replaced by: #'schema.core/Inst
```

When using clojure 1.9.0 or higher